### PR TITLE
Tiny cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 /target
 **/*.rs.bk
 *.pyc
-/cdshealpix/cdshealpix.cpython-36m-x86_64-linux-gnu.so
+/cdshealpix/*.so
 Cargo.lock
 build/
 cdshealpix.egg-info/
 docs/_build
 docs/_templates
 publish_docs.sh
+.idea

--- a/setup.py
+++ b/setup.py
@@ -10,34 +10,38 @@ PYTHON_MAJOR_VERSION = sys.version_info[0]
 version_file_path = os.path.join(os.path.dirname(__file__), "cdshealpix/version.py")
 exec(open(version_file_path).read())
 
+
 # Get the dependencies of cdshealpix by looking into the requirements.txt file
 def get_package_dependencies():
-    dependencies = []
     requirement_file_path = os.path.join(os.path.dirname(__file__), "requirements.txt")
     with open(requirement_file_path, "r") as f_in:
         dependencies = f_in.read().splitlines()
     return dependencies
+
+
+rust_extension = RustExtension(
+    # Package name
+    "cdshealpix.cdshealpix",
+    # The path to the cargo.toml file defining the rust-side wrapper.
+    # This file usually contains the name of the project, its version, the author
+    # and the dependencies of the crate (in our case the rust wrapper depends on the cdshealpix
+    # crate).
+    "Cargo.toml",
+    # Specify python version to setuptools_rust
+    rustc_flags=["--cfg=Py_{}".format(PYTHON_MAJOR_VERSION)],
+    features=["numpy/python{}".format(PYTHON_MAJOR_VERSION)],
+    # Add the --release option when building the rust code
+    debug=False,
+)
 
 setup(
     name="cdshealpix",
     version=__version__,
     packages=find_packages(),
     # setuptools_rust new parameter
-    rust_extensions=[RustExtension(
-        # Package name
-        "cdshealpix.cdshealpix",
-        # The path to the cargo.toml file defining the rust-side wrapper.
-        # This file usually contains the name of the project, its version, the author
-        # and the dependencies of the crate (in our case the rust wrapper depends on the cdshealpix
-        # crate). 
-        'Cargo.toml',
-        # Specify python version to setuptools_rust
-        rustc_flags=['--cfg=Py_{}'.format(PYTHON_MAJOR_VERSION)],
-        features=['numpy/python{}'.format(PYTHON_MAJOR_VERSION)],
-        # Add the --release option when building the rust code
-        debug=False)],
-    provides=['cdshealpix'],
-    #package_dir={'cdshealpix': 'cdshealpix'},
+    rust_extensions=[rust_extension],
+    provides=["cdshealpix"],
+    # package_dir={'cdshealpix': 'cdshealpix'},
     # include the file containing the prototypes
     # package_data={'cdshealpix': ['bindings.h']},
     install_requires=get_package_dependencies(),


### PR DESCRIPTION
Tiny cleanup: change `.gitignore` so that shared lib is also exlcuded on mac where it's `cdshealpix.cpython-36m-darwin.so`, and put `rust_extension` before the `setup` call to have less nesting - I found the indented nesting a bit hard to read.