### PR TITLE
fix: support nan coordinates in bilinear interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `cdshealpix-python` Change Log
 
+## Unreleased
+
+### Fix
+
+* bilinear_interpolation now accepts longitudes and latitudes with nan values (will be reflected by a masked value in the output) [#21]
+
 ## 0.6.5
 
 Released 2023-11-28

--- a/python/cdshealpix/tests/test_nested_healpix.py
+++ b/python/cdshealpix/tests/test_nested_healpix.py
@@ -415,10 +415,11 @@ def test_bilinear_interpolation(depth):
     assert ((ipix >= 0) & (ipix < 12 * (4**depth))).all()
 
 
-@pytest.mark.parametrize("depth", [5, 0, 7, 12, 20, 29])
-def test_bilinear_interpolation2(depth):
-    lon = Longitude([10, 25, 0], u.deg)
-    lat = Latitude([5, 10, 45], u.deg)
+def test_bilinear_interpolation_accepts_nan():
+    lon = Longitude([10, np.nan], unit="deg")
+    lat = Latitude([5, np.nan], unit="deg")
     depth = 5
 
-    ipix, weights = bilinear_interpolation(lon, lat, depth)
+    ipix, _ = bilinear_interpolation(lon, lat, depth)
+
+    assert np.all(ipix.mask == [[False, False, False, False], [True, True, True, True]])


### PR DESCRIPTION
Regression coming from the Rust side where a panic exception was added resulting in failures when coordinates have a NaN (which is allowed in astropy).

We now fill the invalid values (nan and infinites) with a `0*u.deg` before sending to Rust side and then apply a mask to remove these incoherent results from the output. 