### PR TITLE
Fix: support f32 for longitudes and latitudes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,80 +13,39 @@ on: [push, workflow_dispatch]
 # Jobs run in parallel, see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobs
 # Github hosted runner are: see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
 jobs:
-  test-linux64-wheels:
-    # Containers run in Linux
+  test-ubuntu-wheels:
     runs-on: ubuntu-latest
-    # Docker Hub image that 'build-linux-wheels' executes in.
-    # See https://github.com/pypa/manylinux for this particular container:
-    # * CPython 3.8, 3.9, ... installed in /opt/python/<python tag>-<abi tag>
-    container: quay.io/pypa/manylinux2014_x86_64
-    env: {ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true} # Allow using Node16 actions required for CentOS7
-    # We are now in CentOS 7 64 bits
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
-     - name: "Checkout the full project"
-       uses: actions/checkout@v3
-     # We need to install rust in the docker image (else, cargo is already available in github action)
-     - name: "Install Rust"
+     # Checkout the project
+     - name: "Checkout branch"
+       uses: actions/checkout@v4
+     # Test Rust code
+     #- name: Run rust wrapper tests
+     #  run: cargo test --verbose -- --nocapture
+     # Set up python, see https://docs.github.com/en/actions/guides/building-and-testing-python
+     - name: "Set up Python ${{ matrix.python-version }} on ubuntu"
+       uses: actions/setup-python@v4
+       with:
+         python-version: ${{ matrix.python-version }}
+     # Test python code
+     - name: "Build and test wheel for Python ${{ matrix.python-version }} on ubuntu"
        run: |
-         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-     # Build wheels for all pre-installed python version (in /opt/python/, see docker image comment)
-     # installing first maturin and using maturin: https://github.com/PyO3/maturin#pypy
-     # For secrets, see https://docs.github.com/en/actions/reference/encrypted-secrets
-     - name: "Build and run tests"
-       shell: bash
-       run: |
-         source $HOME/.cargo/env
-         for PYBIN in /opt/python/cp*-cp3{8,9,10,11,12,13}/bin; do
-           "${PYBIN}/pip" install virtualenv
-           "${PYBIN}/virtualenv" cdshealpixenv
-           source cdshealpixenv/bin/activate
-           pip install --upgrade pip
-           pip install maturin
-           maturin build --release --compatibility manylinux2014
-           maturin develop --release
-           pip install -r requirements-dev.txt
-           python -m pytest -v
-           deactivate
-           rm -r cdshealpixenv
-         done
-
-  ## So far desactivated because too long to build astropy wheels
-  #test-aarch64-wheels:
-  #  runs-on: ubuntu-latest
-  #  env:
-  #    img: quay.io/pypa/manylinux2014_aarch64
-  #  steps:
-  #    - name: Checkout
-  #      uses: actions/checkout@v4
-  #    - name: "Set up QEMU"
-  #      id: qemu
-  #      uses: docker/setup-qemu-action@v1
-  #    - name: Install dependencies
-  #      run: |
-  #        docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-  #        ${{ env.img }} \
-  #        bash -exc 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-host aarch64-unknown-linux-gnu -y && \
-  #          source $HOME/.cargo/env && \
-  #          for PYBIN in /opt/python/cp3[78910]*/bin; do
-  #            echo "Loop on PYBIN: $PYBIN"
-  #            "${PYBIN}/pip" install virtualenv
-  #            "${PYBIN}/virtualenv" cdshealpixenv
-  #            source cdshealpixenv/bin/activate
-  #            pip install --upgrade pip
-  #            pip install maturin
-  #            cargo build --release --config "net.git-fetch-with-cli = true"
-  #            maturin build --release --compatibility manylinux2014 --target aarch64-unknown-linux-gnu --config "net.git-fetch-with-cli = true"
-  #            maturin develop --release --target aarch64-unknown-linux-gnu --config "net.git-fetch-with-cli = true"
-  #            pip install -r requirements-dev.txt
-  #            cd python
-  #            python -m pytest -v -s cdshealpix/tests/test_nested_healpix.py
-  #            python -m pytest -v -s cdshealpix/tests/test_ring_healpix.py
-  #            cd ..
-  #            pip freeze > requirements-uninstall.txt
-  #            pip uninstall -r requirements-uninstall.txt -y
-  #            deactivate
-  #            rm -r cdshealpixenv/
-  #          done'
+         pip install virtualenv
+         virtualenv cdshealpixenv
+         source cdshealpixenv/bin/activate
+         # Install and use maturin
+         pip install --upgrade pip
+         pip install maturin
+         maturin -V
+         maturin develop --release
+         # Install dependencies
+         pip install -r requirements-dev.txt
+         # Run tests
+         python -m pytest -v
+         deactivate
 
   test-macos-wheels:
     runs-on: macos-latest
@@ -123,11 +82,7 @@ jobs:
          pip install -r requirements-dev.txt
          # Run tests
          python -m pytest -v
-         # Clean
-         #pip freeze > requirements-uninstall.txt
-         #pip uninstall -r requirements-uninstall.txt -y
          deactivate
-         #rm -r cdshealpixenv/
 
   test-windows-wheels:
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+* support longitudes and latitudes that are not of `dtype` `np.float64`. This was broken
+  by numpy 2.0. Before that, the conversion was done silently. See [#35]
+
 ## 0.7.1
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ mapproj = "0.3.0"
 rayon = "1.10"
 
 [dependencies.numpy]
-version = "0.22"
+version = "0.23"
 
 [dependencies.pyo3]
-version = "0.22"
+version = "0.23"
 features = ["extension-module"]
 
 [dependencies.ndarray]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,16 +54,17 @@ locked = false
 fix = true
 force-exclude = true
 output-format = "grouped"
-show-source = true
-ignore-init-module-imports = true
 target-version = "py37"
-extend-select = ["SIM", "D", "UP", "N", "S", "B", "A", "C4", "ICN", "RET", "ARG", "PGH", "RUF"]
-extend-ignore = ["E501"]
+
 # E501: line length (done by black in our case)
 exclude = ["conf.py"]
 extend-include = ["*.ipynb"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint]
+extend-ignore = ["E501"]
+extend-select = ["SIM", "D", "UP", "N", "S", "B", "A", "C4", "ICN", "RET", "ARG", "PGH", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
 # D100: Missing docstring in public module
 # D103: Missing docstring in public function
 # D104: Missing docstring in public package
@@ -74,10 +75,10 @@ extend-include = ["*.ipynb"]
 "notebooks*" = ["D100"]
 "conftest.py" = ["D100"]
 
-[tool.ruff.flake8-errmsg]
+[tool.ruff.lint.flake8-errmsg]
 max-string-length = 20
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"  # Accepts: "google", "numpy", or "pep257"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 # Enrich using https://www.maturin.rs/metadata.html
 [project]
 name = "cdshealpix"
+dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
     "astropy<5.3; python_version == '3.8'",

--- a/python/cdshealpix/tests/test_nested_healpix.py
+++ b/python/cdshealpix/tests/test_nested_healpix.py
@@ -31,7 +31,7 @@ from ..nested.healpix import (
 )
 
 
-@pytest.mark.parametrize("size", [1, 10, 100, 1000, 10000, 100000])
+@pytest.mark.parametrize("size", [1, 10, 100])
 def test_lonlat_to_healpix(size):
     depth = np.random.randint(30)
     lon = Longitude(np.random.rand(size) * 360, u.deg)
@@ -52,7 +52,18 @@ def test_lonlat_to_healpix(size):
     assert ((dy >= 0) & (dy <= 1)).all()
 
 
-@pytest.mark.parametrize("size", [1, 10, 100, 1000, 10000, 100000])
+# regression test for issue #35
+def test_lonlat_to_healpix_float32():
+    healpix = lonlat_to_healpix(
+        lon=Longitude(np.array(3, dtype=np.float32), "deg"),
+        lat=Latitude(np.array(5, dtype=np.float32), "deg"),
+        depth=2,
+    )
+    assert len(healpix) == 1
+    assert healpix[0] == 76
+
+
+@pytest.mark.parametrize("size", [1, 10, 100])
 def test_healpix_to_lonlat(size):
     depth = np.random.randint(30)
     ipixels = np.random.randint(12 * 4**depth, size=size, dtype=np.uint64)

--- a/python/cdshealpix/utils.py
+++ b/python/cdshealpix/utils.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from . import cdshealpix
 
-__all__ = ["to_ring", "from_ring"]
+__all__ = ["from_ring", "to_ring"]
 
 # Raise a ValueError exception if the input
 # HEALPix cells array contains invalid values
@@ -42,8 +42,16 @@ def _validate_lonlat(function):
                 f"'lon' and 'lat' should have the same shape but are of shapes {lon.shape} and {lat.shape}",
             )
         # convert into astropy objects
-        lon = lon if isinstance(lon, Longitude) else Longitude(lon)
-        lat = lat if isinstance(lat, Latitude) else Latitude(lat)
+        lon = (
+            lon
+            if (isinstance(lon, Longitude) and lon.dtype == np.float64)
+            else Longitude(lon, dtype=np.float64)
+        )
+        lat = (
+            lat
+            if (isinstance(lat, Latitude) and lat.dtype == np.float64)
+            else Latitude(lat, dtype=np.float64)
+        )
         return function(lon, lat, *args, **kwargs)
 
     return _validate_lonlat_wrap

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ astropy_healpix
 matplotlib
 pre-commit==2.21.*
 pytest
+ruff==0.8.*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -788,9 +788,9 @@ fn cdshealpix(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     };
 
     (
-      ipix.into_pyarray_bound(py),
-      depth.into_pyarray_bound(py),
-      fully_covered.into_pyarray_bound(py),
+      ipix.into_pyarray(py),
+      depth.into_pyarray(py),
+      fully_covered.into_pyarray(py),
     )
   }
 
@@ -821,9 +821,9 @@ fn cdshealpix(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     };
 
     (
-      ipix.into_pyarray_bound(py),
-      depth.into_pyarray_bound(py),
-      fully_covered.into_pyarray_bound(py),
+      ipix.into_pyarray(py),
+      depth.into_pyarray(py),
+      fully_covered.into_pyarray(py),
     )
   }
 
@@ -860,9 +860,9 @@ fn cdshealpix(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     };
 
     (
-      ipix.into_pyarray_bound(py),
-      depth.into_pyarray_bound(py),
-      fully_covered.into_pyarray_bound(py),
+      ipix.into_pyarray(py),
+      depth.into_pyarray(py),
+      fully_covered.into_pyarray(py),
     )
   }
 
@@ -901,9 +901,9 @@ fn cdshealpix(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     };
 
     (
-      ipix.into_pyarray_bound(py),
-      depth.into_pyarray_bound(py),
-      fully_covered.into_pyarray_bound(py),
+      ipix.into_pyarray(py),
+      depth.into_pyarray(py),
+      fully_covered.into_pyarray(py),
     )
   }
 
@@ -940,9 +940,9 @@ fn cdshealpix(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     };
 
     (
-      ipix.into_pyarray_bound(py),
-      depth.into_pyarray_bound(py),
-      fully_covered.into_pyarray_bound(py),
+      ipix.into_pyarray(py),
+      depth.into_pyarray(py),
+      fully_covered.into_pyarray(py),
     )
   }
 

--- a/src/skymap_functions.rs
+++ b/src/skymap_functions.rs
@@ -37,37 +37,37 @@ pub fn read_skymap<'py>(
         .values()
         .copied()
         .collect::<Vec<u8>>()
-        .into_pyarray_bound(module.py())
+        .into_pyarray(module.py())
         .into_any(),
       SkyMapEnum::ImplicitU64I16(s) => s
         .values()
         .copied()
         .collect::<Vec<i16>>()
-        .into_pyarray_bound(module.py())
+        .into_pyarray(module.py())
         .into_any(),
       SkyMapEnum::ImplicitU64I32(s) => s
         .values()
         .copied()
         .collect::<Vec<i32>>()
-        .into_pyarray_bound(module.py())
+        .into_pyarray(module.py())
         .into_any(),
       SkyMapEnum::ImplicitU64I64(s) => s
         .values()
         .copied()
         .collect::<Vec<i64>>()
-        .into_pyarray_bound(module.py())
+        .into_pyarray(module.py())
         .into_any(),
       SkyMapEnum::ImplicitU64F32(s) => s
         .values()
         .copied()
         .collect::<Vec<f32>>()
-        .into_pyarray_bound(module.py())
+        .into_pyarray(module.py())
         .into_any(),
       SkyMapEnum::ImplicitU64F64(s) => s
         .values()
         .copied()
         .collect::<Vec<f64>>()
-        .into_pyarray_bound(module.py())
+        .into_pyarray(module.py())
         .into_any(),
     })
 }
@@ -202,7 +202,7 @@ where
       None,
     )
     .map_err(|e| PyValueError::new_err(e.to_string()))?;
-    PyArray1::from_slice_bound(py, vec.as_slice()).reshape(Ix3(
+    PyArray1::from_slice(py, vec.as_slice()).reshape(Ix3(
       image_size as usize,
       (image_size << 1) as usize,
       4_usize,
@@ -218,7 +218,7 @@ where
       None,
     )
     .map_err(|e| PyValueError::new_err(e.to_string()))?;
-    PyArray1::from_slice_bound(py, vec.as_slice()).reshape(Ix3(
+    PyArray1::from_slice(py, vec.as_slice()).reshape(Ix3(
       image_size as usize,
       (image_size << 1) as usize,
       4_usize,


### PR DESCRIPTION
Note that we do a copy during the conversion. This was done silently before numpy 2.0. We now have to be explicit about it.
Fixes #35 